### PR TITLE
Automatization for fetching inputs, use nightly, logic simplifications

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -15,6 +15,7 @@ mojo 24.5.0 (e8aacb95)
 ```
 
 ```
+Task            Python      Pypy3       Mojo        parallel    * speedups
 Day01 part1     0.74 ms     0.15 ms     7.70 μs     2.95 μs     * 49 - 252
 Day01 part2     3.03 ms     0.33 ms     0.05 ms     7.11 μs     * 46 - 426
 Day02 part1     0.32 ms     0.11 ms     0.11 ms     0.02 ms     * 4 - 12

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This will create temporary `all_{python3|pypy3|mojo}_{pc|mac}.txt` files. Only P
 Visualisations
 ==============
 
-The vis/ directory contains visualisations code - written in Pythin, with PyGame. You can run each one directly:
+The vis/ directory contains visualisations code - written in Python, with PyGame. You can run each one directly:
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ The final newline should be stripped from the inputs (sorry about this, I actual
 
 Only the standard library is required for Mojo solutions. Python solutions may require numpy. 
 
+You can download all the inputs for all days with the `get-inputs.sh` script. For this to work you need to have cookies.txt in the current directory, which you can get by inspecting your session cookie in the browser and saving it. There is a `cookies.txt.template` file for this purpose so you can:
+
+```
+$ cp cookies.txt.template cookies.txt
+```
+
+And add your session cookie to the file, and then run the script:
+
+```
+$ ./get-inputs.sh
+```
+
 Benchmarking
 ============
 

--- a/array.mojo
+++ b/array.mojo
@@ -37,7 +37,7 @@ struct Array[AType: DType](CollectionElement):
     fn fill(inout self, value: SIMD[AType, 1] = 0):
         initializer = SIMD[AType, Self.simd_width](value)
         for i in range((self.size + Self.simd_width - 1) // Self.simd_width):
-            self.data.store[width=Self.simd_width](i * Self.simd_width, initializer)
+            self.data.store(i * Self.simd_width, initializer)
     
     fn swap(inout self, inout other: Self):
         (self.data, other.data) = (other.data, self.data)
@@ -54,10 +54,10 @@ struct Array[AType: DType](CollectionElement):
         return self.data.load[width=width](ofs)
 
     fn store[width: Int, T: IntLike](self, ofs: T, val: SIMD[AType, width]):
-        self.data.store[width=width](ofs, val)
+        self.data.store(ofs, val)
 
     fn load[T: IntLike](self, ofs: T) -> SIMD[AType, 1]:
         return self.data.load[width=1](ofs)
 
     fn store[T: IntLike](self, ofs: T, val: SIMD[AType, 1]):
-        self.data.store[width=1](ofs, val)
+        self.data.store(ofs, val)

--- a/cookies.txt.template
+++ b/cookies.txt.template
@@ -1,0 +1,3 @@
+
+# Netscape HTTP Cookie File
+.adventofcode.com	TRUE	/	FALSE	0	session	YOUR_SESSION_COOKIE

--- a/day00.mojo
+++ b/day00.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 
 struct Solution:
     var parse: Parser

--- a/day01.mojo
+++ b/day01.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from os.atomic import Atomic
 from collections import List
 from wrappers import run_multiline_task

--- a/day01.mojo
+++ b/day01.mojo
@@ -23,24 +23,19 @@ struct MultiMatcher:
     var pfx: List[Int32]
     var msk: List[Int32]
 
-    fn __init__(inout self, words: List[String]):
+    fn __init__(inout self, words: List[String]) raises:
         self.fcv = List[UInt8]()
         self.pfx = List[Int32]()
         self.msk = List[Int32]()
-        for i in range(len(words)):
-            self.add(words[i])
+        for w in words:
+            self.add(w[])
 
-    fn add(inout self, s: String):
-        l = len(s)
-        # s._buffer[l - 1] == ord(s[i]); but works faster it seems
-        # Not sure if accessing _buffer is discouraged? Probably will break one day.
-        self.fcv.append(s._buffer[l - 1])
+    fn add(inout self, s: String) raises:
+        self.fcv.append(ord(s[-1]))
         var r: Int32 = 0
         var m: Int32 = 0
-        # While iterators are supported in Mojo, none of the standard library
-        # types implement them, have to use range(), which does work.
-        for i in range(l - 1):
-            r = (r << 8) + int(s._buffer[i])
+        for c in s[:-1]:
+            r = (r << 8) + ord(c)
             m = (m << 8) + 0xFF
         self.pfx.append(r)
         self.msk.append(m)

--- a/day01.mojo
+++ b/day01.mojo
@@ -23,7 +23,7 @@ struct MultiMatcher:
     var pfx: List[Int32]
     var msk: List[Int32]
 
-    fn __init__(inout self, words: VariadicList[StringLiteral]):
+    fn __init__(inout self, words: List[String]):
         self.fcv = List[UInt8]()
         self.pfx = List[Int32]()
         self.msk = List[Int32]()
@@ -89,11 +89,11 @@ fn main() raises:
         a1 += lsum
 
     # Construct matchers for all words. When looking backwards, the words have to be reversed.
-    # Fun fact - VariadicList apparently can hold literals, but cannot hold Strings.
+    # Fun fact - List apparently can hold literals, but cannot hold Strings.
     # Variadic since other list variants only make sense in some very specific contexts
     # like when you only use predetermined list sizes and don't iterate over the list.
-    m = MultiMatcher(VariadicList[StringLiteral]("zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"))
-    r = MultiMatcher(VariadicList[StringLiteral]("orez", "eno", "owt", "eerht", "ruof", "evif", "xis", "neves", "thgie", "enin"))
+    m = MultiMatcher(List[String]("zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"))
+    r = MultiMatcher(List[String]("orez", "eno", "owt", "eerht", "ruof", "evif", "xis", "neves", "thgie", "enin"))
 
     # Similar to the part 1, this does the digits checks and also uses the multi-matchers
     # to find words.

--- a/day01.mojo
+++ b/day01.mojo
@@ -101,8 +101,8 @@ fn main() raises:
             var d2 = 0
             # last four characters code
             var l4: Int32 = 0
-            for i in range(s.size):
-                c = int(s[i])
+            for c_ref in s.as_bytes_span():
+                c = int(c_ref[])
                 var d = -1
                 if c >= zero and c <= nine:
                     d = c - zero
@@ -114,8 +114,8 @@ fn main() raises:
                     d1 = d
                     break
             l4 = 0
-            for i in range(s.size - 1, -1, -1):
-                c = int(s[i])
+            for c_ref in s.as_bytes_span()[::-1]:
+                c = int(c_ref[])
                 var d = -1
                 if c >= zero and c <= nine:
                     d = c - zero

--- a/day02.mojo
+++ b/day02.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from collections import Counter
 from os.atomic import Atomic
 from wrappers import run_multiline_task

--- a/day02.mojo
+++ b/day02.mojo
@@ -3,9 +3,6 @@ from collections import Counter
 from os.atomic import Atomic
 from wrappers import run_multiline_task
 
-# Replaces ord('a')
-alias ord_a = ord("a")
-
 
 fn maxballs(line: String) raises -> Counter[String]:
     """

--- a/day02.mojo
+++ b/day02.mojo
@@ -1,4 +1,5 @@
 from parser import *
+from collections import Counter
 from os.atomic import Atomic
 from wrappers import run_multiline_task
 
@@ -6,35 +7,23 @@ from wrappers import run_multiline_task
 alias ord_a = ord("a")
 
 
-fn maxdict(s: StringSlice) raises -> Tuple[Int, Int, Int]:
+fn maxballs(line: String) raises -> Counter[String]:
     """
     Parse a single line and return a dictionary with maximum values for each ball color
     across all the draws. Internally uses hierarchical parsing to split off the header,
     split draws, and then split colors.
     """
-    # Skip header. Game IDs are sequential, anyway.
-    alias cOlon = ord(":")
-    alias cR = ord("r")
-    alias cG = ord("g")
-    start = s.find(cOlon) + 2  # ':'
-    # Top-level parser for draws - semicolon separated
-    draws = make_parser[";"](s[start:])
-    red = green = blue = 0
-    for d in range(draws.length()):
-        # Secondary level parser for comma-separated colors
-        colors = make_parser[","](draws.get(d))
-        for b in range(colors.length()):
-            # split color name and value
-            tok = make_parser[" "](colors.get(b))
-            v = int(atoi(tok.get(0)))
-            col = tok.get(1)
-            if col[0] == cR:
-                red = max(red, v)
-            elif col[0] == cG:
-                green = max(green, v)
-            else:
-                blue = max(blue, v)
-    return (red, green, blue)
+    var games = line.split(": ")[1].split("; ")
+    counter = Counter[String]()
+    for game_ref in games:
+        game = game_ref[]
+        game = game.replace(",", "")
+        toks = game.split(" ")
+        for i in range(len(toks) // 2):
+            cnt = int(toks[i * 2])
+            col = toks[i * 2 + 1]
+            counter[col] = max(counter[col], cnt)
+    return counter
 
 
 fn main() raises:
@@ -48,8 +37,8 @@ fn main() raises:
     @parameter
     fn step1(l: Int):
         try:
-            (r, g, b) = maxdict(lines.get(l))
-            if r <= 12 and g <= 13 and b <= 14:
+            var colors = maxballs(str(lines.get(l)))
+            if colors["red"] <= 12 and colors["green"] <= 13 and colors["blue"] <= 14:
                 sum1 += l + 1
         except:
             pass
@@ -58,8 +47,8 @@ fn main() raises:
     @parameter
     fn step2(l: Int):
         try:
-            (r, g, b) = maxdict(lines.get(l))
-            sum2 += r * g * b
+            var colors = maxballs(str(lines.get(l)))
+            sum2 += colors["red"] * colors["green"] * colors["blue"]
         except:
             pass
 

--- a/day03.mojo
+++ b/day03.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from collections import List
 from wrappers import minibench
 from array import Array

--- a/day03.py
+++ b/day03.py
@@ -12,7 +12,10 @@ def find_nums():
         r = 0
         q = 0
         for x in range(dimx):
-            c = ord(lines[y][x])
+            try:
+                c = ord(lines[y][x])
+            except IndexError:
+                c = 0
             if c >= 48 and c <= 57:
                 d = c - 48
                 r = r * 10 + d
@@ -56,7 +59,11 @@ def part2():
         ly = min(y + 1, dimy - 1)
         for gy in range(sy, ly + 1):
             for gx in range(sx, lx + 1):
-                if lines[gy][gx] == "*":
+                try:
+                    c = lines[gy][gx]
+                except IndexError:
+                    c = ''
+                if c == "*":
                     gk = gy * dimx + gx
                     if gc[gk] != 0:
                         s2 += gc[gk] * v

--- a/day04.mojo
+++ b/day04.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from array import Array
 from wrappers import minibench
 from bit import pop_count

--- a/day05.mojo
+++ b/day05.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from collections import List
 from wrappers import minibench
 

--- a/day06.mojo
+++ b/day06.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from math import sqrt
 from wrappers import minibench
 

--- a/day07.mojo
+++ b/day07.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from math import sqrt
 from wrappers import minibench
 from quicksort import qsort

--- a/day08.mojo
+++ b/day08.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from wrappers import minibench
 from algorithm import parallelize
 from memory import memset

--- a/day09.mojo
+++ b/day09.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from wrappers import minibench
 from memory import memset
 from array import Array

--- a/day09sym.mojo
+++ b/day09sym.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from wrappers import minibench
 from array import Array
 

--- a/day10.mojo
+++ b/day10.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from algorithm import parallelize
 from wrappers import minibench
 from array import Array

--- a/day11.mojo
+++ b/day11.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from wrappers import minibench
 from array import Array
 

--- a/day11hv.mojo
+++ b/day11hv.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from wrappers import minibench
 from array import Array
 

--- a/day12.mojo
+++ b/day12.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from wrappers import run_multiline_task
 from array import Array
 from memory import memcpy, memset

--- a/day13.mojo
+++ b/day13.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from wrappers import minibench
 from array import Array
 from bit import pop_count

--- a/day14.mojo
+++ b/day14.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from wrappers import minibench
 from array import Array
 from collections import List

--- a/day15.mojo
+++ b/day15.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from wrappers import minibench
 from array import Array
 

--- a/day16.mojo
+++ b/day16.mojo
@@ -1,5 +1,5 @@
 from algorithm import parallelize
-from parser import *
+from parser import make_parser
 from wrappers import minibench
 from array import Array
 from os.atomic import Atomic

--- a/day17.mojo
+++ b/day17.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from wrappers import minibench
 from array import Array
 from math import sqrt

--- a/day18.mojo
+++ b/day18.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from wrappers import minibench
 from array import Array
 

--- a/day19.mojo
+++ b/day19.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from wrappers import minibench
 from array import Array
 

--- a/day20.mojo
+++ b/day20.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from wrappers import minibench
 from array import Array
 

--- a/day21.mojo
+++ b/day21.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from wrappers import minibench
 from array import Array
 from utils.loop import unroll

--- a/day22.mojo
+++ b/day22.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from wrappers import minibench
 from array import Array
 from array import Array

--- a/day23.mojo
+++ b/day23.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from algorithm import parallelize
 from wrappers import minibench
 from array import Array

--- a/day24.mojo
+++ b/day24.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from wrappers import minibench
 from array import Array
 from algorithm import parallelize

--- a/day25.mojo
+++ b/day25.mojo
@@ -1,4 +1,4 @@
-from parser import *
+from parser import make_parser
 from wrappers import minibench
 from array import Array
 

--- a/get-inputs.sh
+++ b/get-inputs.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+for DAY in {1..25}
+do
+  echo "Downloading input for day $DAY"
+  curl --silent --cookie cookies.txt \
+       "https://adventofcode.com/2023/day/$DAY/input" \
+       -o "day${DAY}.txt"
+done

--- a/get-inputs.sh
+++ b/get-inputs.sh
@@ -5,5 +5,5 @@ do
   echo "Downloading input for day $DAY"
   curl --silent --cookie cookies.txt \
        "https://adventofcode.com/2023/day/$DAY/input" \
-       -o "day${DAY}.txt"
+       -o "day$(printf "%02d" $DAY).txt"
 done

--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -1,6 +1,6 @@
 [project]
 authors = ["Staszek Pasko <staszek@gmail.com>"]
-channels = ["conda-forge", "https://conda.modular.com/max"]
+channels = ["conda-forge", "https://conda.modular.com/max-nightly"]
 description = "Advent of Code 2023 (in Mojo)"
 name = "aoc2023"
 platforms = ["linux-64"]

--- a/parser.mojo
+++ b/parser.mojo
@@ -1,7 +1,7 @@
 from memory.unsafe_pointer import UnsafePointer
 from memory import memcpy
 from collections import List
-from utils import StringRef
+from utils import StringRef, Span
 
 from wrappers import minibench
 
@@ -36,6 +36,12 @@ struct StringSlice(CollectionElement, Stringable, Formattable):
             end = self.size
         start = idxs.start.or_else(0)
         return StringSlice(self.ptr.offset(start), end - start)
+
+    fn as_bytes_span(self) -> Span[UInt8, __lifetime_of(self)]:
+        return Span[UInt8, __lifetime_of(self)](
+            unsafe_ptr=self.ptr,
+            len=self.size,
+        )
     
     fn format_to(self, inout writer: Formatter):
         writer.write(str(self))

--- a/parser.mojo
+++ b/parser.mojo
@@ -1,6 +1,7 @@
 from memory.unsafe_pointer import UnsafePointer
 from memory import memcpy
 from collections import List
+from utils import StringRef
 
 from wrappers import minibench
 

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,6 @@ if [ `uname` == "Darwin" ]; then
 fi
 echo $suffix
 
-( echo $1.py; python3 $1.py ) | tee -a all_python3_$suffix.txt
-( echo $1.py; pypy3 $1.py ) | tee -a all_pypy3_$suffix.txt
-( echo $1.mojo; mojo $1.mojo ) | tee -a all_mojo_$suffix.txt
+( echo day$1.py; python3 day$1.py ) | tee -a all_python3_$suffix.txt
+( echo day$1.py; pypy3 day$1.py ) | tee -a all_pypy3_$suffix.txt
+( echo day$1.mojo; mojo day$1.mojo ) | tee -a all_mojo_$suffix.txt

--- a/wrappers.mojo
+++ b/wrappers.mojo
@@ -3,7 +3,7 @@ import time
 import benchmark
 
 fn minibench[fun: fn () capturing -> Int64](label: StringLiteral, loops: Int = 100):
-    units = VariadicList[StringLiteral]("ns", "μs", "ms", "s")
+    units = List("ns", "μs", "ms", "s")
     var start = time.now()
     var end = start
     var sloop = loops // 10


### PR DESCRIPTION
- Make it work with Mojo-nightly
- Fix run.sh script
- Typo fixed in the README.md
- Add headers to the benchmarks for readability
- Simplify day01 logic loops by using Mojo stdlib iterators
- Script that download all the inputs from adventofcode
- No need for variadic list, which is mostly used for packing arguments
- Simplify, the `day01.mojo` looping by using `Span`. This needs for this PR to be merged into the nightly release, as the negative steps are not working in Mojo: https://github.com/modularml/mojo/pull/3650
- More pythonic Mojo code in `day02.mojo`. It's slower but more readable. It will be faster overtime as Mojo dicts and strings become fasters.
- Get rid of wildcard imports
- Fix edge cases in `day03.py`
- Fix the calls to `store()` in the `array.mojo` file The unsafe pointers have relaxed signatures in the `.store()` method now

